### PR TITLE
feat: Add command to recalculate account balances

### DIFF
--- a/app/Console/Commands/RecalculateAccountBalances.php
+++ b/app/Console/Commands/RecalculateAccountBalances.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Account;
+use App\Services\Account\AccountBalanceService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class RecalculateAccountBalances extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'accounts:recalculate-balances 
+                            {--user-id= : Recalculate balances for specific user} 
+                            {--account-id= : Recalculate balance for specific account} 
+                            {--dry-run : Show what would be changed without actually changing it}
+                            {--force : Force correction without confirmation for large differences}
+                            {--threshold=0.01 : Minimum difference threshold to consider for correction}';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Recalculate account balances based on transactions';
+
+    public function __construct(
+        private AccountBalanceService $accountBalanceService
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {        $userId = $this->option('user-id');
+        $accountId = $this->option('account-id');
+        $dryRun = $this->option('dry-run');
+        $threshold = (float) $this->option('threshold');
+
+        if ($dryRun) {
+            $this->info('🔍 DRY RUN MODE - No changes will be made');
+        }
+
+        $query = Account::query();
+
+        if ($accountId) {
+            $query->where('id', $accountId);
+        } elseif ($userId) {
+            $query->where('user_id', $userId);
+        }
+
+        $accounts = $query->with('transactions')->get();
+
+        if ($accounts->isEmpty()) {
+            $this->warn('No accounts found with the specified criteria.');
+            return;
+        }
+
+        $this->info("Found {$accounts->count()} account(s) to process...");
+
+        $balanceDiscrepancies = 0;
+        $totalProcessed = 0;
+
+        foreach ($accounts as $account) {
+            $totalProcessed++;
+            
+            $this->info("Processing Account #{$account->id}: {$account->name}");
+
+            // Calculate expected balance
+            $totalIncome = $account->transactions()
+                ->where('type', 'income')
+                ->sum('amount');
+
+            $totalExpenses = $account->transactions()
+                ->where('type', 'expense')
+                ->sum('amount');
+
+            $expectedBalance = $account->initial_balance + $totalIncome - $totalExpenses;
+            $currentBalance = $account->current_balance;
+            $difference = $expectedBalance - $currentBalance;
+
+            $this->table(
+                ['Field', 'Value'],
+                [
+                    ['Initial Balance', number_format($account->initial_balance, 2)],
+                    ['Total Income', number_format($totalIncome, 2)],
+                    ['Total Expenses', number_format($totalExpenses, 2)],
+                    ['Expected Balance', number_format($expectedBalance, 2)],
+                    ['Current Balance', number_format($currentBalance, 2)],
+                    ['Difference', number_format($difference, 2)],
+                ]
+            );
+
+            if (abs($difference) > $threshold) {
+                $balanceDiscrepancies++;
+                
+                if ($difference > 0) {
+                    $this->warn("⚠️  Account is SHORT by $" . number_format(abs($difference), 2));
+                } else {
+                    $this->warn("⚠️  Account has EXCESS of $" . number_format(abs($difference), 2));
+                }                if (!$dryRun) {
+                    // Agregar confirmación para cambios críticos
+                    if (abs($difference) > 100 && !$this->option('force')) {
+                        if (!$this->confirm("⚠️  Large balance difference detected ($" . number_format(abs($difference), 2) . "). Continue with correction?")) {
+                            $this->warn("Skipped correction for Account #{$account->id}");
+                            continue;
+                        }
+                    }
+                    
+                    try {
+                        DB::beginTransaction();
+                          $this->accountBalanceService->recalculateAccountBalance($account);
+                        
+                        // Log de auditoría
+                        \Log::info('Account balance recalculated via command', [
+                            'account_id' => $account->id,
+                            'user_id' => $account->user_id,
+                            'old_balance' => $currentBalance,
+                            'new_balance' => $expectedBalance,
+                            'difference' => $difference,
+                            'command_user' => $this->argument('command') ?? 'system'
+                        ]);
+                        
+                        DB::commit();
+                        
+                        $this->info("✅ Balance corrected for Account #{$account->id}");
+                    } catch (\Exception $e) {
+                        DB::rollBack();
+                        $this->error("❌ Failed to correct balance for Account #{$account->id}: " . $e->getMessage());
+                    }
+                } else {
+                    $this->info("🔍 Would correct balance for Account #{$account->id}");
+                }
+            } else {
+                $this->info("✅ Account balance is correct");
+            }
+
+            $this->newLine();
+        }
+
+        // Summary
+        $this->info("📊 SUMMARY:");
+        $this->info("Total accounts processed: {$totalProcessed}");
+        $this->info("Accounts with balance discrepancies: {$balanceDiscrepancies}");
+        
+        if ($dryRun && $balanceDiscrepancies > 0) {
+            $this->info("To apply changes, run the command without --dry-run option");
+        }
+
+        if ($balanceDiscrepancies === 0) {
+            $this->info("🎉 All account balances are correct!");
+        }
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -20,7 +20,7 @@ use InvalidArgumentException;
 class CategoryController extends Controller
 {
     use HasAuthenticatedUser, HasLogging;
-    
+
     public function __construct(
         private CategoryService $categoryService
     ) {}
@@ -32,43 +32,43 @@ class CategoryController extends Controller
     {
         try {
             $filters = [];
-            
+
             // Text filters
             if ($request->filled('search')) {
                 $filters['search'] = $request->get('search');
             }
-            
+
             if ($request->filled('color')) {
                 $filters['color'] = $request->get('color');
             }
-            
+
             // Enum/Boolean filters
             if ($request->has('type')) {
                 $filters['type'] = $request->get('type');
             }
-            
+
             if ($request->has('is_active')) {
                 $filters['is_active'] = $request->get('is_active');
             }
-            
+
             // Pagination
-            $perPage = $request->get('per_page', 15);
-            $perPage = min($perPage, 100); 
-            
+            $perPage = $request->get('per_page', 50);
+            $perPage = min($perPage, 100);
+
             $categories = $this->categoryService->getCategoriesForUser($this->userId(), $filters, $perPage);
-            
+
             return response()->json([
                 'success' => true,
                 'data' => new CategoryCollection($categories),
                 'message' => 'Categorías obtenidas exitosamente',
                 'status' => 200
             ], 200);
-            
+
         } catch (Exception $e) {
             $this->logError('Error al obtener categorías', [
                 'filters' => $filters ?? []
             ], $e);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Error al obtener las categorías',
@@ -92,12 +92,12 @@ class CategoryController extends Controller
                 'message' => 'Categoría creada exitosamente',
                 'status' => 201
             ], 201);
-            
+
         } catch (Exception $e) {
             $this->logCrudError('create', 'categoría', 'store', $e, [
                 'data' => $request->validated()
             ]);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Error al crear la categoría',
@@ -114,30 +114,30 @@ class CategoryController extends Controller
     {
         try {
             $category = Category::where('user_id', $this->userId())->findOrFail($id);
-            
+
             return response()->json([
                 'success' => true,
                 'data' => new CategoryResource($category),
                 'message' => 'Categoría obtenida exitosamente',
                 'status' => 200
             ], 200);
-            
+
         } catch (ModelNotFoundException $e) {
             $this->logWarning('Categoría no encontrada', [
                 'category_id' => $id
             ]);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Categoría no encontrada',
                 'status' => 404
             ], 404);
-            
+
         } catch (Exception $e) {
             $this->logError('Error al obtener categoría', [
                 'category_id' => $id
             ], $e);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Error al obtener la categoría',
@@ -154,7 +154,7 @@ class CategoryController extends Controller
     {
         try {
             $category = Category::where('user_id', $this->userId())->findOrFail($id);
-            
+
             $updatedCategory = $this->categoryService->updateCategory($category->id, $request->validated(), $this->userId());
 
             return response()->json([
@@ -163,25 +163,25 @@ class CategoryController extends Controller
                 'message' => 'Categoría actualizada exitosamente',
                 'status' => 200
             ], 200);
-            
+
         } catch (ModelNotFoundException $e) {
             $this->logError('Categoría no encontrada para actualizar', [
                 'category_id' => $id,
                 'data' => $request->validated()
             ], $e);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Categoría no encontrada',
                 'status' => 404
             ], 404);
-            
+
         } catch (Exception $e) {
             $this->logError('Error al actualizar categoría en update', [
                 'category_id' => $id,
                 'data' => $request->validated()
             ], $e);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Error al actualizar la categoría',
@@ -198,31 +198,31 @@ class CategoryController extends Controller
     {
         try {
             $category = Category::where('user_id', $this->userId())->findOrFail($id);
-            
+
             $this->categoryService->deleteCategory($category->id, $this->userId());
-                 
+
             return response()->json([
                 'success' => true,
                 'message' => 'Categoría eliminada exitosamente',
                 'status' => 200
             ], 200);
-            
+
         } catch (ModelNotFoundException $e) {
             $this->logError('Categoría no encontrada para eliminar', [
                 'category_id' => $id
             ], $e);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Categoría no encontrada',
                 'status' => 404
             ], 404);
-            
+
         } catch (Exception $e) {
             $this->logCrudError('delete', 'categoría', 'destroy', $e, [
                 'category_id' => $id
             ]);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Error al eliminar la categoría',
@@ -239,32 +239,32 @@ class CategoryController extends Controller
     {
         try {
             $category = Category::where('user_id', $this->userId())->findOrFail($id);
-            
+
             $updatedCategory = $this->categoryService->toggleCategoryStatus($category->id, $this->userId());
-            
+
             return response()->json([
                 'success' => true,
                 'data' => new CategoryResource($updatedCategory),
                 'message' => 'Estado de categoría actualizado exitosamente',
                 'status' => 200
             ], 200);
-            
+
         } catch (ModelNotFoundException $e) {
             $this->logWarning('Categoría no encontrada para cambiar estado', [
                 'category_id' => $id
             ]);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Categoría no encontrada',
                 'status' => 404
             ], 404);
-            
+
         } catch (Exception $e) {
             $this->logError('Error al cambiar estado de categoría', [
                 'category_id' => $id
             ], $e);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Error al cambiar el estado de la categoría',
@@ -284,38 +284,38 @@ class CategoryController extends Controller
             if (!in_array($type, ['income', 'expense'])) {
                 throw new InvalidArgumentException('Tipo de categoría inválido. Debe ser income o expense.');
             }
-    
+
             $userId = $this->userId();
-            
+
             // Usar el método existente con filtro de tipo
             $categories = $this->categoryService->getCategoriesForUser(
-                $userId, 
+                $userId,
                 ['type' => $type], // Filtrar por tipo
                 1000 // Un número alto para obtener todas las categorías
             );
-    
+
             return response()->json([
                 'success' => true,
                 'data' => $categories->items(), // Obtener solo los elementos sin paginación
                 'message' => 'Categorías obtenidas exitosamente'
             ]);
-    
+
         } catch (InvalidArgumentException $e) {
             $this->logError('Tipo de categoría inválido', [
                 'type' => $type,
                 'error_message' => $e->getMessage()
             ], $e);
-    
+
             return response()->json([
                 'success' => false,
                 'message' => $e->getMessage()
             ], 400);
-    
+
         } catch (Exception $e) {
             $this->logCrudError('read', 'categorías por tipo', 'getByType', $e, [
                 'type' => $type
             ]);
-    
+
             return response()->json([
                 'success' => false,
                 'message' => 'Error interno del servidor'
@@ -330,30 +330,30 @@ class CategoryController extends Controller
     {
         try {
             $restoredCategory = $this->categoryService->restoreCategory((int)$id, $this->userId());
-            
+
             return response()->json([
                 'success' => true,
                 'data' => new CategoryResource($restoredCategory),
                 'message' => 'Categoría restaurada exitosamente',
                 'status' => 200
             ], 200);
-            
+
         } catch (ModelNotFoundException $e) {
             $this->logError('Categoría no encontrada para restaurar', [
                 'category_id' => $id
             ], $e);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Categoría no encontrada',
                 'status' => 404
             ], 404);
-            
+
         } catch (Exception $e) {
             $this->logCrudError('restore', 'categoría', 'restore', $e, [
                 'category_id' => $id
             ]);
-            
+
             return response()->json([
                 'success' => false,
                 'message' => 'Error al restaurar la categoría',

--- a/app/Http/Controllers/Api/V1/TransactionController.php
+++ b/app/Http/Controllers/Api/V1/TransactionController.php
@@ -234,4 +234,66 @@ class TransactionController extends Controller
             ], 500);
         }
     }
+
+    /**
+     * Get transaction statistics by currency
+     */
+    public function statsByCurrency(): JsonResponse
+    {
+        try {
+            $stats = $this->transactionService->getTransactionStatsByCurrency($this->userId());
+
+            return response()->json([
+                'success' => true,
+                'data' => $stats,
+                'message' => 'Estadísticas por moneda obtenidas exitosamente',
+            ], 200);
+        } catch (Exception $e) {
+            $this->logError('Error al obtener estadísticas por moneda en TransactionController@statsByCurrency', [
+                'user_id' => $this->userId()
+            ], $e);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Error al obtener las estadísticas por moneda',
+                'error' => config('app.debug') ? $e->getMessage() : 'Error interno del servidor',
+            ], 500);
+        }
+    }
+
+    /**
+     * Get monthly trends
+     */
+    public function monthlyTrends(Request $request): JsonResponse
+    {
+        try {
+            $months = $request->get('months', 12); // Por defecto 12 meses
+            $trends = $this->transactionService->getMonthlyTrends($this->userId(), $months);
+
+            // Log para debugging
+            Log::info('Monthly trends requested', [
+                'user_id' => $this->userId(),
+                'months' => $months,
+                'trends_count' => count($trends),
+                'trends_sample' => array_slice($trends, 0, 2) // Primeros 2 elementos
+            ]);
+
+            return response()->json([
+                'success' => true,
+                'data' => $trends,
+                'message' => 'Tendencias mensuales obtenidas exitosamente',
+            ], 200);
+        } catch (Exception $e) {
+            $this->logError('Error al obtener tendencias mensuales en TransactionController@monthlyTrends', [
+                'user_id' => $this->userId(),
+                'months' => $months ?? null
+            ], $e);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Error al obtener las tendencias mensuales',
+                'error' => config('app.debug') ? $e->getMessage() : 'Error interno del servidor',
+            ], 500);
+        }
+    }
 }

--- a/app/Http/Resources/Transaction/TransactionResource.php
+++ b/app/Http/Resources/Transaction/TransactionResource.php
@@ -11,28 +11,28 @@ class TransactionResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'account' => [
+            'account' => $this->account ? [
                 'id' => $this->account->id,
                 'name' => $this->account->name,
-                'type' => $this->account->type
-            ],
-            'category' => [
+                'type' => $this->account->type,
+                'currency' => $this->account->currency,
+            ] : null,
+            'category' => $this->category ? [
                 'id' => $this->category->id,
                 'name' => $this->category->name,
                 'type' => $this->category->type
-            ],
+            ] : null,
             'type' => $this->type,
             'amount' => $this->amount,
             'description' => $this->description,
-            'transaction_date' => $this->transaction_date->format('Y-m-d'),
+            'transaction_date' => $this->transaction_date ? $this->transaction_date->format('Y-m-d') : null,
             'reference_number' => $this->reference_number,
             'notes' => $this->notes,
             'is_recurring' => $this->is_recurring,
             'recurring_frequency' => $this->recurring_frequency,
             'tags' => $this->tags,
-            'created_at' => $this->created_at->format('Y-m-d H:i:s'),
-            'updated_at' => $this->updated_at->format('Y-m-d H:i:s'),
-            
+            'created_at' => $this->created_at ? $this->created_at->format('Y-m-d H:i:s') : null,
+            'updated_at' => $this->updated_at ? $this->updated_at->format('Y-m-d H:i:s') : null,
             // Metadata
             'can_edit' => $this->when(
                 $request->user() && $request->user()->id === $this->user_id,

--- a/app/Repositories/Category/CategoryRepository.php
+++ b/app/Repositories/Category/CategoryRepository.php
@@ -25,8 +25,7 @@ class CategoryRepository
         // Apply filters
         if (!empty($filters['search'])) {
             $query->where(function ($q) use ($filters) {
-                $q->where('name', 'like', '%' . $filters['search'] . '%')
-                  ->orWhere('description', 'like', '%' . $filters['search'] . '%');
+                $q->where('name', 'like', '%' . $filters['search'] . '%');
             });
         }
 

--- a/app/Services/Account/AccountBalanceService.php
+++ b/app/Services/Account/AccountBalanceService.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Services\Account;
+
+use App\Models\Account;
+use App\Models\Transaction;
+use App\Repositories\Account\AccountRepository;
+use App\Traits\HasLogging;
+use Exception;
+use Illuminate\Support\Facades\DB;
+
+class AccountBalanceService
+{
+    use HasLogging;
+
+    public function __construct(
+        private AccountRepository $accountRepository
+    ) {}
+
+    /**
+     * Update account balance after transaction creation
+     */
+    public function updateBalanceForTransaction(Transaction $transaction): void
+    {
+        $account = $transaction->account;
+        
+        if (!$account) {
+            throw new Exception('Account not found for transaction');
+        }
+
+        $this->logInfo('Updating account balance for transaction', [
+            'account_id' => $account->id,
+            'transaction_id' => $transaction->id,
+            'transaction_type' => $transaction->type,
+            'transaction_amount' => $transaction->amount,
+            'current_balance' => $account->current_balance
+        ]);
+
+        $this->adjustAccountBalance($account, $transaction->type, $transaction->amount);
+    }
+
+    /**
+     * Revert account balance changes when transaction is updated
+     */
+    public function revertBalanceForTransaction(Transaction $originalTransaction): void
+    {
+        $account = $originalTransaction->account;
+        
+        if (!$account) {
+            throw new Exception('Account not found for transaction');
+        }
+
+        $this->logInfo('Reverting account balance for transaction', [
+            'account_id' => $account->id,
+            'transaction_id' => $originalTransaction->id,
+            'transaction_type' => $originalTransaction->type,
+            'transaction_amount' => $originalTransaction->amount,
+            'current_balance' => $account->current_balance
+        ]);
+
+        // Revert by doing the opposite operation
+        $oppositeType = $originalTransaction->type === 'income' ? 'expense' : 'income';
+        $this->adjustAccountBalance($account, $oppositeType, $originalTransaction->amount);
+    }
+
+    /**
+     * Update account balance when transaction is deleted
+     */
+    public function revertBalanceForDeletedTransaction(Transaction $deletedTransaction): void
+    {
+        $this->revertBalanceForTransaction($deletedTransaction);
+    }
+
+    /**
+     * Update account balance when transaction is restored
+     */
+    public function updateBalanceForRestoredTransaction(Transaction $restoredTransaction): void
+    {
+        $this->updateBalanceForTransaction($restoredTransaction);
+    }
+
+    /**
+     * Adjust account balance based on transaction type and amount
+     */
+    private function adjustAccountBalance(Account $account, string $transactionType, float $amount): void
+    {
+        $currentBalance = $account->current_balance;
+        
+        switch ($transactionType) {
+            case 'income':
+                $newBalance = $currentBalance + $amount;
+                break;
+            case 'expense':
+                $newBalance = $currentBalance - $amount;
+                break;
+            case 'transfer':
+                // For transfers, this method should be called twice:
+                // Once for the source account (as expense) and once for destination account (as income)
+                throw new Exception('Transfer transactions require special handling');
+            default:
+                throw new Exception("Unknown transaction type: {$transactionType}");
+        }
+
+        $this->logInfo('Adjusting account balance', [
+            'account_id' => $account->id,
+            'transaction_type' => $transactionType,
+            'amount' => $amount,
+            'old_balance' => $currentBalance,
+            'new_balance' => $newBalance
+        ]);
+
+        // Update the account balance
+        $this->accountRepository->updateBalance($account, $newBalance);
+    }
+
+    /**
+     * Recalculate account balance from all transactions
+     * This can be used for data integrity checks or repairs
+     */
+    public function recalculateAccountBalance(Account $account): void
+    {
+        $this->logInfo('Recalculating account balance from transactions', [
+            'account_id' => $account->id,
+            'current_balance' => $account->current_balance,
+            'initial_balance' => $account->initial_balance
+        ]);
+
+        // Get all transactions for this account
+        $totalIncome = $account->transactions()
+            ->where('type', 'income')
+            ->sum('amount');
+
+        $totalExpenses = $account->transactions()
+            ->where('type', 'expense')
+            ->sum('amount');
+
+        // Calculate the correct balance
+        $calculatedBalance = $account->initial_balance + $totalIncome - $totalExpenses;
+
+        $this->logInfo('Recalculated account balance', [
+            'account_id' => $account->id,
+            'initial_balance' => $account->initial_balance,
+            'total_income' => $totalIncome,
+            'total_expenses' => $totalExpenses,
+            'calculated_balance' => $calculatedBalance,
+            'current_balance' => $account->current_balance
+        ]);
+
+        // Update if different
+        if (abs($calculatedBalance - $account->current_balance) > 0.01) {
+            $this->logWarning('Account balance mismatch detected and corrected', [
+                'account_id' => $account->id,
+                'expected_balance' => $calculatedBalance,
+                'actual_balance' => $account->current_balance,
+                'difference' => $calculatedBalance - $account->current_balance
+            ]);
+
+            $this->accountRepository->updateBalance($account, $calculatedBalance);
+        }
+    }
+}

--- a/app/Services/Auth/AuthService.php
+++ b/app/Services/Auth/AuthService.php
@@ -19,7 +19,7 @@ class AuthService
     {
         try {
             DB::beginTransaction();
-            
+
             $user = User::create([
                 'name' => $data['name'],
                 'email' => $data['email'],
@@ -59,7 +59,7 @@ class AuthService
             }
 
             // Revocar tokens anteriores (opcional)
-            $user->tokens()->delete();
+            // $user->tokens()->delete();
 
             $token = $user->createToken('auth-token')->plainTextToken;
 

--- a/routes/api/v1/api.php
+++ b/routes/api/v1/api.php
@@ -52,6 +52,8 @@ Route::middleware('auth:sanctum')->group(function () {
         ->withTrashed();
         Route::get('stats', [TransactionController::class, 'stats'])
         ->name('transactions.stats');
+        Route::get('stats-by-currency', [TransactionController::class, 'statsByCurrency'])
+        ->name('transactions.stats-by-currency');
     });
 
     Route::apiResource('transactions', TransactionController::class);

--- a/tests/Feature/Services/TransactionServiceAccountBalanceTest.php
+++ b/tests/Feature/Services/TransactionServiceAccountBalanceTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Services\Transaction\TransactionService;
+use App\Services\Account\AccountBalanceService;
+use App\Repositories\Transaction\TransactionRepository;
+use App\Repositories\Account\AccountRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Sanctum\Sanctum;
+
+class TransactionServiceAccountBalanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private TransactionService $transactionService;
+    private User $user;
+    private Account $account;
+    private Category $incomeCategory;
+    private Category $expenseCategory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->user = User::factory()->create();
+        $this->account = Account::factory()->create([
+            'user_id' => $this->user->id,
+            'initial_balance' => 1000.00,
+            'current_balance' => 1000.00
+        ]);
+        $this->incomeCategory = Category::factory()->create([
+            'user_id' => $this->user->id,
+            'type' => 'income'
+        ]);
+        $this->expenseCategory = Category::factory()->create([
+            'user_id' => $this->user->id,
+            'type' => 'expense'
+        ]);
+
+        // Set up the service with dependencies
+        $transactionRepository = new TransactionRepository(new Transaction());
+        $accountRepository = new AccountRepository(new Account());
+        $accountBalanceService = new AccountBalanceService($accountRepository);
+        $this->transactionService = new TransactionService($transactionRepository, $accountBalanceService);
+
+        // Authenticate user
+        Sanctum::actingAs($this->user);
+    }
+
+    public function test_creating_income_transaction_increases_account_balance()
+    {
+        // Arrange
+        $initialBalance = $this->account->current_balance;
+        $transactionAmount = 500.00;
+
+        $transactionData = [
+            'account_id' => $this->account->id,
+            'category_id' => $this->incomeCategory->id,
+            'type' => 'income',
+            'amount' => $transactionAmount,
+            'description' => 'Test income',
+            'transaction_date' => now()->format('Y-m-d')
+        ];
+
+        // Act
+        $transaction = $this->transactionService->createTransaction($transactionData);
+
+        // Assert
+        $this->account->refresh();
+        $expectedBalance = $initialBalance + $transactionAmount;
+        
+        $this->assertEquals($expectedBalance, $this->account->current_balance);
+        $this->assertInstanceOf(Transaction::class, $transaction);
+        $this->assertEquals($transactionAmount, $transaction->amount);
+    }
+
+    public function test_creating_expense_transaction_decreases_account_balance()
+    {
+        // Arrange
+        $initialBalance = $this->account->current_balance;
+        $transactionAmount = 300.00;
+
+        $transactionData = [
+            'account_id' => $this->account->id,
+            'category_id' => $this->expenseCategory->id,
+            'type' => 'expense',
+            'amount' => $transactionAmount,
+            'description' => 'Test expense',
+            'transaction_date' => now()->format('Y-m-d')
+        ];
+
+        // Act
+        $transaction = $this->transactionService->createTransaction($transactionData);
+
+        // Assert
+        $this->account->refresh();
+        $expectedBalance = $initialBalance - $transactionAmount;
+        
+        $this->assertEquals($expectedBalance, $this->account->current_balance);
+        $this->assertInstanceOf(Transaction::class, $transaction);
+        $this->assertEquals($transactionAmount, $transaction->amount);
+    }
+
+    public function test_updating_transaction_adjusts_account_balance_correctly()
+    {
+        // Arrange - Create initial transaction
+        $transaction = Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'account_id' => $this->account->id,
+            'category_id' => $this->incomeCategory->id,
+            'type' => 'income',
+            'amount' => 200.00
+        ]);
+
+        // Manually update account balance to simulate the transaction being processed
+        $this->account->update(['current_balance' => 1200.00]); // 1000 + 200
+
+        $updateData = [
+            'amount' => 500.00, // Changed from 200 to 500
+            'type' => 'income'
+        ];
+
+        // Act
+        $updatedTransaction = $this->transactionService->updateTransaction($transaction, $updateData);
+
+        // Assert
+        $this->account->refresh();
+        $expectedBalance = 1500.00; // 1000 (initial) + 500 (new amount)
+        
+        $this->assertEquals($expectedBalance, $this->account->current_balance);
+        $this->assertEquals(500.00, $updatedTransaction->amount);
+    }
+
+    public function test_updating_transaction_type_adjusts_account_balance_correctly()
+    {
+        // Arrange - Create initial income transaction
+        $transaction = Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'account_id' => $this->account->id,
+            'category_id' => $this->incomeCategory->id,
+            'type' => 'income',
+            'amount' => 300.00
+        ]);
+
+        // Manually update account balance to simulate the transaction being processed
+        $this->account->update(['current_balance' => 1300.00]); // 1000 + 300
+
+        $updateData = [
+            'category_id' => $this->expenseCategory->id,
+            'type' => 'expense',
+            'amount' => 300.00
+        ];
+
+        // Act
+        $updatedTransaction = $this->transactionService->updateTransaction($transaction, $updateData);
+
+        // Assert
+        $this->account->refresh();
+        $expectedBalance = 700.00; // 1000 (initial) - 300 (now expense)
+        
+        $this->assertEquals($expectedBalance, $this->account->current_balance);
+        $this->assertEquals('expense', $updatedTransaction->type);
+    }
+
+    public function test_deleting_transaction_reverts_account_balance()
+    {
+        // Arrange - Create transaction
+        $transaction = Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'account_id' => $this->account->id,
+            'category_id' => $this->incomeCategory->id,
+            'type' => 'income',
+            'amount' => 400.00
+        ]);
+
+        // Manually update account balance to simulate the transaction being processed
+        $this->account->update(['current_balance' => 1400.00]); // 1000 + 400
+
+        // Act
+        $result = $this->transactionService->deleteTransaction($transaction);
+
+        // Assert
+        $this->assertTrue($result);
+        $this->account->refresh();
+        $expectedBalance = 1000.00; // Back to initial balance
+        
+        $this->assertEquals($expectedBalance, $this->account->current_balance);
+        $this->assertSoftDeleted('transactions', ['id' => $transaction->id]);
+    }
+
+    public function test_restoring_transaction_reapplies_account_balance()
+    {
+        // Arrange - Create and delete transaction
+        $transaction = Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'account_id' => $this->account->id,
+            'category_id' => $this->incomeCategory->id,
+            'type' => 'income',
+            'amount' => 350.00
+        ]);
+
+        $transaction->delete();
+
+        // Act
+        $restoredTransaction = $this->transactionService->restoreTransaction($transaction->id, $this->user->id);
+
+        // Assert
+        $this->account->refresh();
+        $expectedBalance = 1350.00; // 1000 + 350
+        
+        $this->assertEquals($expectedBalance, $this->account->current_balance);
+        $this->assertNotNull($restoredTransaction);
+        $this->assertNull($restoredTransaction->deleted_at);
+    }
+
+    public function test_multiple_transactions_cumulative_balance_effect()
+    {
+        // Arrange
+        $initialBalance = $this->account->current_balance;
+
+        // Act - Create multiple transactions
+        $this->transactionService->createTransaction([
+            'account_id' => $this->account->id,
+            'category_id' => $this->incomeCategory->id,
+            'type' => 'income',
+            'amount' => 100.00,
+            'description' => 'Income 1',
+            'transaction_date' => now()->format('Y-m-d')
+        ]);
+
+        $this->transactionService->createTransaction([
+            'account_id' => $this->account->id,
+            'category_id' => $this->expenseCategory->id,
+            'type' => 'expense',
+            'amount' => 50.00,
+            'description' => 'Expense 1',
+            'transaction_date' => now()->format('Y-m-d')
+        ]);
+
+        $this->transactionService->createTransaction([
+            'account_id' => $this->account->id,
+            'category_id' => $this->incomeCategory->id,
+            'type' => 'income',
+            'amount' => 200.00,
+            'description' => 'Income 2',
+            'transaction_date' => now()->format('Y-m-d')
+        ]);
+
+        // Assert
+        $this->account->refresh();
+        $expectedBalance = $initialBalance + 100.00 - 50.00 + 200.00; // 1250.00
+        
+        $this->assertEquals($expectedBalance, $this->account->current_balance);
+    }
+}


### PR DESCRIPTION
- Implemented `RecalculateAccountBalances` command to recalculate account balances based on transactions.
- Added options for user ID, account ID, dry run, force correction, and threshold for discrepancies.
- Integrated `AccountBalanceService` for balance recalculations and logging.
- Enhanced `TransactionController` with new endpoints for transaction statistics by currency and monthly trends.
- Updated `TransactionService` to handle balance updates on transaction creation, update, deletion, and restoration.
- Created tests for transaction service to ensure correct balance adjustments on various operations.
- Refactored `CategoryRepository` to simplify search filters.